### PR TITLE
MOD Deep review of the relay management

### DIFF
--- a/NostrSharp/Relay/Models/NSRelayConfig.cs
+++ b/NostrSharp/Relay/Models/NSRelayConfig.cs
@@ -21,8 +21,8 @@ namespace NostrSharp.Relay.Models
         public NSRelayConfig(string uri) : this(uri, null) { }
         public NSRelayConfig(string uri, RelayPermissions permissions) : this(new Uri(!uri.StartsWith("wss://") ? $"wss://{uri.Replace("https://", "")}" : uri.Replace("https://", "")), null, null, permissions) { }
         public NSRelayConfig(Uri uri) : this(uri, null) { }
-        public NSRelayConfig(Uri uri, RelayPermissions permissions) : this(uri, null, null, permissions) { }
-        public NSRelayConfig(Uri uri, TimeSpan? reconnectTimeout, TimeSpan? errorReconnectTimeout, RelayPermissions permissions)
+        public NSRelayConfig(Uri uri, RelayPermissions? permissions) : this(uri, null, null, permissions) { }
+        public NSRelayConfig(Uri uri, TimeSpan? reconnectTimeout, TimeSpan? errorReconnectTimeout, RelayPermissions? permissions)
         {
             Uri = uri;
             ReconnectTimeout = reconnectTimeout;

--- a/NostrSharp/Relay/NSRelay.cs
+++ b/NostrSharp/Relay/NSRelay.cs
@@ -3,6 +3,7 @@ using NostrSharp.Relay.Enums;
 using NostrSharp.Relay.Models;
 using NostrSharp.Relay.Models.Messagges;
 using NostrSharp.Settings;
+using NostrSharp.Tools;
 using System;
 using System.Collections.Concurrent;
 using System.IO;
@@ -34,9 +35,10 @@ namespace NostrSharp.Relay
         public event EventHandler<Uri> OnConnectionError;
         public event EventHandler<Uri> OnUserRequestedDisconnection;
         public event EventHandler<Uri> OnServerRequestedDisconnection;
+        public event EventHandler<Uri, RelayNIP11Metadata> OnRelayMetadata;
 
 
-        public event EventHandler<Uri, NResponseAuth> OnAuthRequest;
+        public event EventHandler<Uri, NResponseAuth> OnAuthResponse;
         public event EventHandler<Uri, NResponseEvent> OnEvent;
         public event EventHandler<Uri, NResponseCount> OnCount;
         public event EventHandler<Uri, NResponseEose> OnEose;
@@ -48,35 +50,46 @@ namespace NostrSharp.Relay
 
 
         public NSRelayConfig Configurations { get; private set; }
-        public RelayNIP11Metadata Capabilities { get; private set; } = new();
-        public string Name { get; set; }
-        public bool IsRunning => WSC is not null ? WSC.State == WebSocketState.Open : false;
-
-
         private ClientWebSocket WSC { get; set; } = new ClientWebSocket();
-        private CancellationToken cancellationToken { get; set; } = default;
+        public CancellationTokenSource CancelToken { get; private set; }
+        public Guid SubscriptionId { get; set; } = Guid.NewGuid();
+
+
+        public RelayNIP11Metadata Capabilities { get; private set; } = new();
+        public Uri Uri { get; init; }
+        public string HostName { get; init; }
+        /// <summary>
+        /// True if the Web Socket is connected
+        /// </summary>
+        public bool IsRunning => WSC is not null ? WSC.State == WebSocketState.Open : false;
 
 
         private ConcurrentQueue<byte[]> _receivedData = new();
 
 
-        public NSRelay(NSRelayConfig config, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Initialize this relay connection instance with an optional CancellationToken
+        /// </summary>
+        /// <param name="config">Must contain a valid uri for the relay</param>
+        /// <param name="cancellationTokenSource"></param>
+        public NSRelay(NSRelayConfig config, CancellationTokenSource? cancellationTokenSource = null)
         {
             if (config.Uri.ToString().EndsWith("/"))
                 config.Uri = new Uri(config.Uri.ToString().Substring(0, config.Uri.ToString().Length - 1));
 
+            if (cancellationTokenSource is null)
+                cancellationTokenSource = new CancellationTokenSource();
             Configurations = config;
-            Name = config.Uri.Host;
-            this.cancellationToken = cancellationToken;
+            Uri = config.Uri;
+            HostName = config.Uri.Host;
+            this.CancelToken = cancellationTokenSource;
         }
 
 
-        public void SetCapabilities(RelayNIP11Metadata capabilities)
-        {
-            Capabilities = capabilities;
-        }
-
-
+        /// <summary>
+        /// Try to start a Web Socket connection with the configured relay.
+        /// </summary>
+        /// <returns>True if everything go smooth or if the connection was already running, false otherwise</returns>
         public async Task<bool> TryRun()
         {
             if (Configurations is null)
@@ -86,12 +99,18 @@ namespace NostrSharp.Relay
 
             try
             {
-                await WSC.ConnectAsync(Configurations.Uri, cancellationToken);
+                SubscriptionId = Guid.NewGuid();
+
+                CancelToken = new CancellationTokenSource();
+                await WSC.ConnectAsync(Configurations.Uri, CancelToken.Token);
                 if (IsRunning)
                 {
-                    OnInitialConnectionEstablished?.Invoke(Configurations.Uri);
+                    await GetRelayCapabilities();
+
                     Receive();
                     Emit();
+
+                    OnInitialConnectionEstablished?.Invoke(Configurations.Uri);
                 }
                 return IsRunning;
             }
@@ -101,25 +120,40 @@ namespace NostrSharp.Relay
                 return IsRunning;
             }
         }
+        /// <summary>
+        /// Try to stop the ongoing Web Socket connection
+        /// </summary>
+        /// <returns>True if everything go smooth or if the connection was already stopped, false otherwise</returns>
         public async Task<bool> TryStop()
         {
             if (!IsRunning)
                 return true;
 
-            CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
             try
             {
-                await WSC.CloseAsync(WebSocketCloseStatus.NormalClosure, "stop requested", cancelTokenSource.Token);
-                cancelTokenSource.Cancel();
+                if (CancelToken is null)
+                    CancelToken = new CancellationTokenSource();
+                await SendClose(new NRequestClose(SubscriptionId.ToString()), CancelToken.Token);
+                await WSC.CloseAsync(WebSocketCloseStatus.NormalClosure, "stop requested", CancelToken.Token);
+                CancelToken.Cancel();
+                CancelToken.Dispose();
                 return !IsRunning;
             }
             catch (Exception ex)
             {
-                cancelTokenSource.Cancel();
+                if (CancelToken is not null)
+                {
+                    CancelToken.Cancel();
+                    CancelToken.Dispose();
+                }
                 OnError?.Invoke(Configurations.Uri, ex.Message);
                 return !IsRunning;
             }
         }
+        /// <summary>
+        /// Perform a TryStop and a TryRun
+        /// </summary>
+        /// <returns>True if the Web Socket connection is now running, false otherwise</returns>
         public async Task<bool> TryReconnect()
         {
             try
@@ -136,34 +170,94 @@ namespace NostrSharp.Relay
         }
 
 
+        /// <summary>
+        /// Ask NIP-11 metadata to the relay
+        /// </summary>
+        /// <returns></returns>
+        private async Task GetRelayCapabilities()
+        {
+            RelayNIP11Metadata? nip11RelayMetadata = await NSUtilities.GetNIP11RelayMetadata(Configurations.Uri);
+            if (nip11RelayMetadata is not null)
+            {
+                Capabilities = nip11RelayMetadata;
+                OnRelayMetadata?.Invoke(Configurations.Uri, nip11RelayMetadata);
+            }
+        }
+
+
+        /// <summary>
+        /// Try to send an Authentication request to the configured relay.
+        /// NOTE: if this method return true it doesn't mean the authentication has been succesfully.
+        /// To check if the authentication has been succesfully you need to subscribe to the event "OnAuthResponse".
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="token"></param>
+        /// <returns>True if the send has been succesful, false otherwise</returns>
+        public async Task<bool> SendAuthentication(NRequestAuth request, CancellationToken? token = null)
+        {
+            return await Send(JsonConvert.SerializeObject(request, SerializerCustomSettings.Settings), token);
+        }
+        /// <summary>
+        /// Try to send an event to the configured relay.
+        /// NOTE: if this method return true it doesn't mean the event has been accepted by the relay.
+        /// To check if the event has been accepted, subscribe to "OnOk" event and check if the property
+        /// "Accepted" is true and the property "EventId" is the same of the event you sent.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="token"></param>
+        /// <returns>True if the send has been succesful, false otherwise</returns>
         public async Task<bool> SendEvent(NRequestEvent request, CancellationToken? token = null)
         {
             return await Send(JsonConvert.SerializeObject(request, SerializerCustomSettings.Settings), token);
         }
-        public async Task<bool> SendSubscriptioFilter(NRequestReq request, CancellationToken? token = null)
+        /// <summary>
+        /// Try to send a filter request to the configured relay.
+        /// The result of the request can be seen by subscribing to the "OnEvent" event
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="token"></param>
+        /// <returns>True if the send has been succesful, false otherwise</returns>
+        public async Task<bool> SendFilter(NRequestReq request, CancellationToken? token = null)
         {
+            if (string.IsNullOrEmpty(request.SubscriptionId) || !Guid.TryParse(request.SubscriptionId, out _))
+                request.SubscriptionId = SubscriptionId.ToString();
             return await Send(JsonConvert.SerializeObject(request, SerializerCustomSettings.Settings), token);
         }
+        /// <summary>
+        /// Try to send a filter request to the configured relay.
+        /// The result of the request can be seen by subscribing to the "OnCount" event
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="token"></param>
+        /// <returns>True if the send has been succesful, false otherwise</returns>
+        public async Task<bool> SendCount(NRequestCount request, CancellationToken? token = null)
+        {
+            if (string.IsNullOrEmpty(request.SubscriptionId) || !Guid.TryParse(request.SubscriptionId, out _))
+                request.SubscriptionId = SubscriptionId.ToString();
+            return await Send(JsonConvert.SerializeObject(request, SerializerCustomSettings.Settings), token);
+        }
+        /// <summary>
+        /// Try to send a close subscription request.
+        /// NOTE: this method doesn't close the Web Socket connection, but possibly the connection will be closed
+        /// by the relay
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="token"></param>
+        /// <returns>True if the send has been succesful, false otherwise</returns>
         public async Task<bool> SendClose(NRequestClose request, CancellationToken? token = null)
         {
+            if (string.IsNullOrEmpty(request.SubscriptionId) || !Guid.TryParse(request.SubscriptionId, out _))
+                request.SubscriptionId = SubscriptionId.ToString();
             return await Send(JsonConvert.SerializeObject(request, SerializerCustomSettings.Settings), token);
         }
+
+
         public async Task<bool> Send(string msg, CancellationToken? token = null)
         {
             if (!IsRunning)
                 return false;
 
-            try
-            {
-                ArraySegment<byte> data = new ArraySegment<byte>(Encoding.UTF8.GetBytes(msg));
-                await WSC.SendAsync(data, WebSocketMessageType.Text, true, token is null ? cancellationToken : (CancellationToken)token);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                OnError?.Invoke(Configurations.Uri, ex.Message);
-                return false;
-            }
+            return await Send(new ArraySegment<byte>(Encoding.UTF8.GetBytes(msg)), token);
         }
         public async Task<bool> Send(byte[] msg, CancellationToken? token = null)
         {
@@ -172,7 +266,7 @@ namespace NostrSharp.Relay
 
             try
             {
-                await WSC.SendAsync(msg, WebSocketMessageType.Text, true, token is null ? cancellationToken : (CancellationToken)token);
+                await WSC.SendAsync(msg, WebSocketMessageType.Text, true, token is null ? CancelToken.Token : (CancellationToken)token);
                 return true;
             }
             catch (Exception ex)
@@ -188,7 +282,7 @@ namespace NostrSharp.Relay
 
             try
             {
-                await WSC.SendAsync(msg, WebSocketMessageType.Text, true, token is null ? cancellationToken : (CancellationToken)token);
+                await WSC.SendAsync(msg, WebSocketMessageType.Text, true, token is null ? CancelToken.Token : (CancellationToken)token);
                 return true;
             }
             catch (Exception ex)
@@ -202,7 +296,7 @@ namespace NostrSharp.Relay
         private async Task Receive()
         {
             ArraySegment<byte> buffer = new ArraySegment<byte>(new byte[1024]);
-            while (IsRunning && !cancellationToken.IsCancellationRequested)
+            while (IsRunning && !CancelToken.IsCancellationRequested)
             {
 
                 try
@@ -212,7 +306,7 @@ namespace NostrSharp.Relay
                         WebSocketReceiveResult rm;
                         do
                         {
-                            rm = await WSC.ReceiveAsync(buffer, cancellationToken);
+                            rm = await WSC.ReceiveAsync(buffer, CancelToken.Token);
                             if (rm.MessageType == WebSocketMessageType.Binary || buffer.Array is null)
                                 continue;
 
@@ -236,14 +330,12 @@ namespace NostrSharp.Relay
         }
         private async Task Emit()
         {
-            while (IsRunning && !cancellationToken.IsCancellationRequested)
-            {
+            while (IsRunning && !CancelToken.IsCancellationRequested)
                 try
                 {
                     if (!_receivedData.TryDequeue(out byte[]? receiveData) || receiveData is null)
                     {
                         await Task.Delay(200);
-                        //ThreadUtilities.PauseThread(100);
                         continue;
                     }
 
@@ -253,7 +345,6 @@ namespace NostrSharp.Relay
                 {
                     OnError?.Invoke(Configurations.Uri, ex.Message);
                 }
-            }
         }
 
 
@@ -274,7 +365,7 @@ namespace NostrSharp.Relay
 
                 string type = parts[0].ToString().ToUpperInvariant();
                 if (type.Contains(NMessageTypes.Authentication))
-                    OnAuthRequest?.Invoke(Configurations.Uri, ParseResponse<NResponseAuth>(msg));
+                    OnAuthResponse?.Invoke(Configurations.Uri, ParseResponse<NResponseAuth>(msg));
                 else if (type.Contains(NMessageTypes.Count))
                     OnCount?.Invoke(Configurations.Uri, ParseResponse<NResponseCount>(msg));
                 else if (type.Contains(NMessageTypes.Event))
@@ -293,7 +384,7 @@ namespace NostrSharp.Relay
         {
             T? result = JsonConvert.DeserializeObject<T>(msg, SerializerCustomSettings.Settings);
             if (result is null)
-                throw new ArgumentException("Non è possibile deserializzare il messaggio");
+                throw new ArgumentException("Cannot deserialize the response");
             return (T)result;
         }
 


### PR DESCRIPTION
NSRelay
- Moved CancellationTokenSource inside this class as a public property
- Moved the subscription id inside this class. I don't know why i didn't put it here at first.
- Moved NIP-11 metadata request in this class, right after a succesful connection.
- Added public property Uri
- Added new event when a relay respond with it's NIP-11 metadata
- Added SendAuthentication method
- Added SendCount method
- Added a check on the subscription id string: if missing gets automatically added
- Renamed public property Name to HostName
- Renamed SendSubscriptioFilter to SendFilter
- Renamed event OnAuthRequest in OAuthResponse because it is a response
- Added many comments

NSMultiRelay
- Removed CancellationTokenSource because is now inside NSRelay class
- Removed the request for NIP-11 relay metadata because is now inside NSRelay class
- Fixed all send methods to support all relays or just one
- Added a check on the subscription id string: if missing gets automatically added
- Added many properties to easily get running and non running relays instances and uris
- Added new event when a relay respond with it's NIP-11 metadata
- Renamed GetRelayByName in GetRelayByUri
- Renamed event OnAuthRequest in OAuthResponse because it is a response

NSMain
- Added connection method for a single relay
- Added reconnection method both for single relay and lists of them
- Added utility methods to check if relay connection is running or not by it's uri
- Added OnConnectionClosed event
- Fixed all send method to support multiple and single relay
- Removed subscription id management because it's now inside NSRelay class. -Removed RelaysStatus property because the status can be retrieved from NSRelay instances

NEvent
- Added public readonly property to check if the event has already been signed
- Removed the id placeholder during sign process because is now useless

NSRelayConfig
- Added receive and send buffer size as parameters